### PR TITLE
Install analytics tracking script on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,9 @@
       }
     </script>
 
+    <!-- Ahrefs Web Analytics -->
+    <script src="https://analytics.ahrefs.com/analytics.js" data-key="BmDX1xhBBd2vqfZDBay+6A" async></script>
+
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="manifest" href="/site.webmanifest" />


### PR DESCRIPTION
Install Ahrefs Web Analytics by adding the tracking script to the <head> section of index.html. The script includes the project-specific data-key (BmDX1xhBBd2vqfZDBay+6A) and loads asynchronously to avoid blocking page rendering.

This will enable:
- Visitor tracking and analytics
- Page view monitoring
- User behavior insights
- SEO performance metrics

The script is placed after Google Analytics and before the favicon section for optimal loading order.